### PR TITLE
#166626412 Add dropdown to mark property as sold

### DIFF
--- a/UI/user/my_properties.html
+++ b/UI/user/my_properties.html
@@ -112,6 +112,7 @@
                             <th>City</th>
                             <th>State</th>
                             <th colspan="2">Action</th>
+                            <th>Status (Mark as)</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -123,8 +124,17 @@
                             <td>6045B Princeton Avenue</td>
                             <td>Princeton</td>
                             <td>Lagos</td>
-                            <td><button class="button button--small btn-edit">Edit</button><button class="button button--small btn-update no-display">Update</button></td>
-                            <td><button class="button button--small btn-delete">Delete</button><button class="button button--small btn-cancel no-display">Cancel</button></td>
+                            <td><button class="button button--small btn-edit">Edit</button><button
+                                    class="button button--small btn-update no-display">Update</button></td>
+                            <td><button class="button button--small btn-delete">Delete</button><button
+                                    class="button button--small btn-cancel no-display">Cancel</button></td>
+                            <td>
+                                <select name="property_status">
+                                    <option value="null">------------</option>
+                                    <option value="available">Available</option>
+                                    <option value="sold">Sold</option>
+                                </select>
+                            </td>
                         </tr>
                         <tr>
                             <td>2</td>
@@ -134,8 +144,17 @@
                             <td>6045B Princeton Avenue</td>
                             <td>Princeton</td>
                             <td>Lagos</td>
-                            <td><button class="button button--small btn-edit">Edit</button><button class="button button--small btn-update no-display">Update</button></td>
-                            <td><button class="button button--small btn-delete">Delete</button><button class="button button--small btn-cancel no-display">Cancel</button></td>
+                            <td><button class="button button--small btn-edit">Edit</button><button
+                                    class="button button--small btn-update no-display">Update</button></td>
+                            <td><button class="button button--small btn-delete">Delete</button><button
+                                    class="button button--small btn-cancel no-display">Cancel</button></td>
+                            <td>
+                                <select name="property_status">
+                                    <option value="null">------------</option>
+                                    <option value="available">Available</option>
+                                    <option value="sold">Sold</option>
+                                </select>
+                            </td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
#### What does this PR do?
- It creates a dropdown for agents to be able to mark their posted property Ad as either sold/available

#### Description of Task to be completed?
- Create a new table column
- Add a dropdown list containing the options ```Available``` and ```Sold```

#### How should this be manually tested?
- N/A

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)
![mark_sold](https://user-images.githubusercontent.com/13166712/60584317-d8335f00-9d84-11e9-9daf-017fe14f8756.PNG)
