### PR TITLE
bug(image-upload): add await keyword to dataURI

### DIFF
--- a/API/middlewares/imageHandler.js
+++ b/API/middlewares/imageHandler.js
@@ -20,7 +20,6 @@ class ImageHandler {
           error: 'Invalid Image Type',
         });
       }
-      console.log(req.body);
       return next();
     } catch (error) {
       return error;

--- a/API/middlewares/imageHandler.js
+++ b/API/middlewares/imageHandler.js
@@ -1,7 +1,7 @@
 // import cloud from '../utils/cloudinaryConfig';
 // import multerUpload from '../utils/multerConfig';
 import { dataUri } from '../utils/multerConfig';
-import { CloudinaryConfig, uploader } from '../utils/cloudinaryConfig';
+import { uploader } from '../utils/cloudinaryConfig';
 // import { uploader } from '../utils/cloudinaryConfig';
 
 class ImageHandler {
@@ -10,7 +10,7 @@ class ImageHandler {
       if (req.file && req.file.mimetype.startsWith('image/')) {
         let file;
         if (req.file) {
-          file = dataUri(req).content;
+          file = await dataUri(req).content;
           const result = await uploader.upload(file);
           req.body.image_url = result.url;
         }
@@ -20,6 +20,7 @@ class ImageHandler {
           error: 'Invalid Image Type',
         });
       }
+      console.log(req.body);
       return next();
     } catch (error) {
       return error;

--- a/API/test/test.js
+++ b/API/test/test.js
@@ -174,7 +174,7 @@ describe('POST /api/v1/property', () => {
       });
   });
 
-  it('Should create property ad', (done) => {
+  it('Should upload an image to cloudinary', (done) => {
     const req = chai.request(app)
       .post('/api/v1/property/');
     req.set('Authorization', authToken)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "migration": "babel-node ./API/db/migration/createTables",
     "destroy_db": "babel-node ./API/db/migration/dropTables",
-    "test": "mocha --require babel-core/register API/test/**/*.js --timeout 1000000 --exit || true",
+    "test": "mocha --require babel-core/register API/test/**/*.js --timeout 100000 --exit || true",
     "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "coveralls": "nyc --reporter=lcov --reporter=text-lcov npm test",
     "dev": "nodemon bin/dev",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "migration": "babel-node ./API/db/migration/createTables",
     "destroy_db": "babel-node ./API/db/migration/dropTables",
-    "test": "mocha --require babel-core/register API/test/**/*.js --timeout 100000 --exit || true",
+    "test": "mocha --require babel-core/register API/test/**/*.js --timeout 1000000 --exit || true",
     "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "coveralls": "nyc --reporter=lcov --reporter=text-lcov npm test",
     "dev": "nodemon bin/dev",


### PR DESCRIPTION
#### What does this PR do?
- It makes the dataURI method asynchronous

#### Description of Task to be completed?
- Add the keyword `await` to the dataURI function in imageHandler.js

#### How should this be manually tested?
- On postman, try to create a new property advert using multipart/form-data. For the property field, select an image. 

#### Any background context you want to provide?
- When an agent is creating a new property advert, the agent is required to upload an image of the property. This property image should be received by the application and stored in cloudinary, and only the image URL should be stored in the database.

#### What are the relevant pivotal tracker stories?
- [#167390308](https://www.pivotaltracker.com/story/show/167390308)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/13166712/61506814-4b6edf00-a9db-11e9-84b3-fbe30ccb6052.png)
