### PR TITLE
#167452911 use a plus (+) symbol to add a new property

### DIFF
--- a/UI/user/my_properties.html
+++ b/UI/user/my_properties.html
@@ -63,13 +63,15 @@
     <main class="content-section">
         <section class="content-section__main content-section__main-2">
             <section class="container--post-property">
-                <p class="container__title container__desc"><a href="javascript:void(0)" class="property_ad">Click to
-                        Post a Property Ad</a></p>
+                <p class="container__title container__desc"><a href="javascript:void(0)" class="property_ad">+</a></p>
+                <!-- <p class="container__title container__desc"><a href="javascript:void(0)" class="property_ad">Click to
+                        Post a Property Ad</a></p> -->
                 <form action="./my_properties.html" class="no-display container--form">
+                    <p class="container__title container__desc">Post a Property Ad</p>
                     <div class="row">
                         <div class="column1_1">
                             <label>Image URL</label>
-                            <input type="url" name="prop-url" placeholder="e.g. https://cloudinary.com/example-image">
+                            <input type="file" name="prop-url">
                         </div>
                         <div class="column1_2">
                             <label>Property Type</label>
@@ -100,6 +102,7 @@
                 </form>
             </section>
             <section class="my_property_section">
+                <p class="container__title container__desc">My Property Listing</p>
                 <hr>
                 <table class="my_property_table">
                     <thead>


### PR DESCRIPTION
#### What does this PR do?
- It allows an agent to access a form to create a new property ad by simply clicking on a plus (+) symbol
- It removes the confusing header when viewing the `my_properties` page

#### Description of Task to be completed?
- Add `+` symbol in place of the previous header
- Make the previous header part of the form
- Add a new header to distinguish between creating a new property ad and viewing already listed ads

#### How should this be manually tested?
- View the `my_properties` page on a browser

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- [#167452911](https://www.pivotaltracker.com/story/show/167452911)

#### Screenshots (if appropriate)
![myproperty1](https://user-images.githubusercontent.com/13166712/61791578-4f9f6000-ae12-11e9-8fd5-33788037655a.PNG)
![myproperty2](https://user-images.githubusercontent.com/13166712/61791579-4f9f6000-ae12-11e9-9c2f-cfa85b595143.PNG)
